### PR TITLE
Fix infinite loop issue when using anidb2 on Windows

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -430,7 +430,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None, **kwargs): #
     
     # Local custom mapping file
     anidb_id, dir = anidb2_match.group('guid').lower(), os.path.join(root, path)
-    while dir and dir is not os.sep:
+    while dir and os.path.splitdrive(dir)[1] != os.sep:
       scudlee_filename_custom = os.path.join(dir, ANIDB_TVDB_MAPPING_CUSTOM)
       if os.path.exists( scudlee_filename_custom ):
         with open(scudlee_filename_custom, 'r') as scudlee_file:


### PR DESCRIPTION
The problem  is root for linux is '/' but Windows is 'X:\' where X is the drive letter.

So the while loop will never be false and loop forever.

The cleanest solution I could come up with was to use [os.path.splitdrive](https://docs.python.org/2/library/os.path.html#os.path.splitdrive)

Here are some simple tests I ran using Python interactive console

Windows:
```
>>> os.path.splitdrive("S:\\Anime\\Gundam_00")
('S:', '\\Anime\\Gundam_00')
>>> os.path.splitdrive("S:\\")
('S:', '\\')
```

Linux:
```
>>> os.path.splitdrive("/mnt/Anime/Gundam_00")
('', '/mnt/Anime/Gundam_00')
>>> os.path.splitdrive("/")
('', '/')
```

Also you can't use `is` or `is not` when the two are of different type. It worked fine before with string comparison. See example below:

Windows:
```
>>> "\\" is not "\\"
False
"\\" != "\\"
False
>>> "\\" is not os.sep
True
>>> "\\" != os.sep
False
```
Linux:
```
>>> "/" is not "/"
False
>>> "/" != "/"
False
>>> "/" is not os.sep
True
>>> "/" != os.sep
False
```

As you can see, is not doesn't work in this case. is/is not checks to see if the two objects are the same object. Where as  == and != checks if the two objects have the same/different values.

Just some stackoverflow topic I found:
http://stackoverflow.com/questions/5782203/python-difference-between-and-is-not

