### PR TITLE
Removal of persisted Scudlee changes

### DIFF
--- a/anime-list-corrections.xml
+++ b/anime-list-corrections.xml
@@ -1,27 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <anime-list>
-    <anime anidbid="3395" tvdbid="79604" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
-        <name>Black Lagoon</name>
-        <mapping-list>
-            <mapping anidbseason="0" tvdbseason="0">;5-0;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="4597" tvdbid="79604" defaulttvdbseason="1" episodeoffset="12" tmdbid="" imdbid="">
-        <name>Black Lagoon: The Second Barrage</name>
-        <mapping-list>
-            <mapping anidbseason="0" tvdbseason="0">;1-5;2-6;3-7;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="10027" tvdbid="272849" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
-        <name>Space Dandy</name>
-        <mapping-list>
-            <mapping anidbseason="0" tvdbseason="0">;1-0;2-1;3-2</mapping>
-        </mapping-list>
-    </anime>
     <anime anidbid="9227" tvdbid="262098" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
         <name>Girls und Panzer</name>
         <mapping-list>
-            <mapping anidbseason="1" tvdbseason="1">;1-1;2-2;3-3;4-4;5-5;6-6;7-7;8-8;9-9;10-10;11-11;12-12;</mapping>
             <mapping anidbseason="0" tvdbseason="0">;0-3;3-4;4-5;5-6;6-7;7-8;8-9;9-10;10-11;11-12;12-13;13-14;14-15;15-16;16-16;17-34;18-29;19-23;20-25;21-17;22-21;23-27;24-18;25-22;26-28;27-19;28-26;29-0;30-20;31-24;32-0;33-33;34-0;</mapping>
         </mapping-list>
     </anime>
@@ -35,63 +16,6 @@
         <name>Girls und Panzer Gekijouban</name>
         <mapping-list>
             <mapping anidbseason="1" tvdbseason="0">;1-37;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="5842" tvdbid="82834" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
-        <name>Bounen no Xamdou11</name>
-    </anime>
-    <anime anidbid="8655" tvdbid="244061" defaulttvdbseason="0" episodeoffset="" tmdbid="83380" imdbid="">
-        <name>Gekijouban Steins;Gate: Fuka Ryouiki no Deja vu</name>
-        <mapping-list>
-            <mapping anidbseason="1" tvdbseason="0">;1-2;2-0;3-0;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="9042" tvdbid="269319" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
-        <name>Fate/Kaleid Liner Prisma Illya</name>
-        <mapping-list>
-            <mapping anidbseason="0" tvdbseason="0">;1-2;2-3;3-4;4-5;5-6;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="9900" tvdbid="269319" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
-        <name>Fate/Kaleid Liner Prisma Illya (2014)</name>
-        <mapping-list>
-            <mapping anidbseason="1" tvdbseason="0">;1-1;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="10091" tvdbid="269319" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
-        <name>Fate/Kaleid Liner Prisma Illya Zwei!</name>
-        <mapping-list>
-            <mapping anidbseason="0" tvdbseason="0">;1-7;2-8;3-9;4-10;5-11;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="10804" tvdbid="269319" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
-        <name>Fate/Kaleid Liner Prisma Illya Zwei! (2015)</name>
-        <mapping-list>
-            <mapping anidbseason="1" tvdbseason="0">;1-12;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="10833" tvdbid="269319" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
-        <name>Fate/Kaleid Liner Prisma Illya Zwei Herz!</name>
-        <mapping-list>
-            <mapping anidbseason="0" tvdbseason="0">;1-13;2-14;3-15;4-16;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="11747" tvdbid="289884" defaulttvdbseason="0" episodeoffset="" tmdbid="374056" imdbid="">
-        <name>Gekijouban Hibike! Euphonium: Kitauji Koukou Suisougaku Bu e Youkoso</name>
-        <mapping-list>
-            <mapping anidbseason="1" tvdbseason="0">;1-9;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="11123" tvdbid="293088" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
-        <name>One Punch Man</name>
-        <mapping-list>
-            <mapping anidbseason="0" tvdbseason="0">;1-2;2-3;3-4;4-5;5-6;6-7;</mapping>
-        </mapping-list>
-    </anime>
-    <anime anidbid="11637" tvdbid="293088" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
-        <name>One Punch Man: Road to Hero</name>
-        <mapping-list>
-            <mapping anidbseason="1" tvdbseason="0">;1-1;</mapping>
         </mapping-list>
     </anime>
 </anime-list>


### PR DESCRIPTION
@ZeroQI, please peer review. All removed are already persisted in Scudlee
https://raw.githubusercontent.com/ScudLee/anime-lists/master/anime-list-master.xml

Note that some of the 'mapping-list' in this file are also direct duplication of the 'defaulttvdbseason' / 'episodeoffset' values and redundant. So might not be exactly seen in Scudlee's file.

EX:
```
   <anime anidbid="11637" tvdbid="293088" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
       <name>One Punch Man: Road to Hero</name>
       <mapping-list>
           <mapping anidbseason="1" tvdbseason="0">;1-1;</mapping>
       </mapping-list>
   </anime>
```