### PR TITLE
Add environment variable X_PLEX_TOKEN as a secondary conf option

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -132,6 +132,9 @@ PLEX_LIBRARY, PLEX_LIBRARY_URL = {}, "http://127.0.0.1:32400/library/sections/" 
 if os.path.isfile(os.path.join(LOG_PATH, "X-Plex-Token.id")):
   Log.info("'X-Plex-Token.id' file present")
   with open(os.path.join(LOG_PATH, "X-Plex-Token.id"), 'r') as token_file:  PLEX_LIBRARY_URL += "?X-Plex-Token=" + token_file.read().strip()
+elif 'X_PLEX_TOKEN' in os.environ:
+  Log.info("'X_PLEX_TOKEN' environment variable present")
+  PLEX_LIBRARY_URL += "?X-Plex-Token=" + os.environ['X_PLEX_TOKEN']
 try:
   library_xml = etree.fromstring(urlopen(PLEX_LIBRARY_URL, context=SSL_CONTEXT).read())
   for library in library_xml.iterchildren('Directory'):


### PR DESCRIPTION
Related to https://github.com/ZeroQI/Hama.bundle/issues/42 and others.

I needed this to quickly test and use the plug-in with a docker image without having to store the token on it. So I just add the option as a fallback option. 