### PR TITLE
Fix shebang on shell updater

### DIFF
--- a/Scanners/Series/Shell Update scanner.sh
+++ b/Scanners/Series/Shell Update scanner.sh
@@ -1,2 +1,2 @@
-#/bin/sh
+#!/usr/bin/env sh
 wget "https://raw.githubusercontent.com/ZeroQI/Absolute-Series-Scanner/master/Scanners/Series/Absolute%20Series%20Scanner.py" -O "Absolute Series Scanner.py"


### PR DESCRIPTION
 - Added "!" after "#" (with this now shebang really works).
 - Changed to "/usr/bin/env sh" in order to extend compatibility to non Linux environments.