### PR TITLE
Major Update: Addition of 'anidb3' & 'anidb4' mode

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -717,7 +717,7 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
               if source=="anidb4":
                 if season_map[prequel_id]['min'] != 1 and 'Prequel' in relations_map[prequel_id] and relations_map[prequel_id]['Prequel'][0] in season_map:
                   a, b = get_prequel_info(relations_map[prequel_id]['Prequel'][0])             # Recurively go down the tree following prequels
-                  return (a+1+season_map[prequel_id]['max']-season_map[prequel_id]['min'], 0)  # Add 1 to the season number and start at episode 0
+                  return (a+1+season_map[prequel_id]['max']-season_map[prequel_id]['min'], 0) if str(a).isdigit() else ('', '')  # Add 1 to the season number and start at episode 0
                 return (2, 0) if season_map[prequel_id]['min'] == 1 else ('', '')              # Root prequel is season 1 so start counting up. Else was a sequel of specials only so leave mapping alone
             if source=="anidb3":
               if season_map[id]['min'] == 0 and 'Prequel' in relations_map[id] and relations_map[id]['Prequel'][0] in season_map:


### PR DESCRIPTION
**Hey @ZeroQI,**

So.....in the work of updating my anime entries over to 'anidb2' mode setup to combine related series animes, I was hit with an issue on multiple TVDB series setups.
The issue was that TVDB had some sequel/prequel entries annoyingly listed as season 0 specials.

I started to try and write custom ScudLee mapping for each I was seeing to move them out of season 0. But I found too many and was concerned I might be missing some (I was). So I have now codded it into the scanner to fix these entries automatically as mode 'anidb3'.

----

### 'anidb3' - Uses ScudLee mapping to map the AniDB series to TVDB entries BUT overrides the mapping for TVDB season 0 entries and puts them in AniDB relational order by appending to existing seasons or adding new seasons at after the last TVDB season

**NOTE**: AniDB series that are prequels to the series that is mapped to TVDB season 1 will stay as specials.

**NOTE**: Episode metadata will be blank for those adjusted series episodes till HAMA is updated to handle this new mode.

### Example of "Date a Live":
In AniDB its relation map [HERE](http://anidb.net/perl-bin/animedb.pl?show=rel&aid=8808) has:
```
1. Date a Live (a8808)
2. Date a Live: Date to Date (a9734)
3. Date a Live II (a9935)
4. Date a Live II: Kurumi Star Festival (a10568)
```
But in the TVDB entry [HERE](https://www.thetvdb.com/series/date-a-live/seasons/all) it has that sequel/prequel placement mapped as:
```
TVDB s1   = Date a Live (a8808)
TVDB s0e1 = Date a Live: Date to Date (a9734)
TVDB s2   = Date a Live II (a9935)
TVDB s0e2 = Date a Live II: Kurumi Star Festival (a10568)
TVDB s3   = TBD (prep entry in TVDB)
```
So when I put all 4 series as mode 'anidb2', it uses the ScudLee mapping as expected.
But that annoyingly puts the AniDB entries out of order for proper sequential viewing in Plex. 
So you would have to remember to go back and forth from season 0 to watch it in the correct order. (S1->S0->S2->S0) 💢 

This mode will correct that order jumping by applying adjustments to those TVDB season 0 entries using AniDB (sequel/prequel) relation mapping.

(Note: This was pulled from inline code comments so code has documentation on the what/why)
**Step 1** - It will still do the same 'anidb2' ScudLee mapping info.
**Step 2** - If the series is listed as 'defaulttvdbseason' == '0' loaded from step 1, it will now try to figure out if it should truly be there and need to update the loaded mapping info.
Else, it will not to anything and skip Step 3 and do nothing to the mapping and just act as if it was in 'anidb2' mode
**Step 3** - Check if it needs to to update the mapping:
- Load in ScudLee & ASS mapping again and merge them
- Find each entry that has the same tvdbid listing and store its max season#
- Get the max season number from TVDB for the tvdb id
- Set the max season for a series with 'defaulttvdbseason' == 'a'
- Generate a relations map using all anidbid's using the same tvdbid stored earlier
- Recursively go down the tree following prequels using the relations map
-- If the prequel is a tvdb special as well, check its' prequel
-- Else:
--- Root prequel is a special so leave as special
--- Root prequel season is < max season so add to the end of the Prequel season (adding 100 to the episode offset)
--- Root prequel season is >= max season so add to the season after max
- If the root prequel is not a special, it will clear out all 'mappingList' 's1*' mapping entries and update the 'defaulttvdbseason' & 'episodeoffset' with the new values. As only 's1' entries are cleared out, all anidb special mapping still gets applied.

So in practice, that turns the "Date a Live" entries to:
```
#### FROM: ####
s1   - Date a Live (a8808)
s0e1 - Date a Live: Date to Date (a9734)
s2   - Date a Live II (a9935)
s0e2 - Date a Live II: Kurumi Star Festival (a10568)
s3   - TBD (prep entry in TVDB)
#### TO: ####
s1     - Date a Live (a8808)
s1e101 - Date a Live: Date to Date (a9734)
s2     - Date a Live II (a9935)
s2e101 - Date a Live II: Kurumi Star Festival (a10568)
```
### MORE EXAMPLES:
**"Baka and Test: Summon the Beasts"**
http://anidb.net/perl-bin/animedb.pl?show=rel&aid=6747
https://www.thetvdb.com/series/baka-and-test-summon-the-beasts/seasons/all
```
#### FROM: ####
s1       - Baka to Test to Shoukanjuu (a6747)
s0e09/10 - Baka to Test to Shoukanjuu: Matsuri (a8085)
s2       - Baka to Test to Shoukanjuu Ni! (a8235)
#### TO: ####
s1         - Baka to Test to Shoukanjuu (a6747)
s1e101/102 - Baka to Test to Shoukanjuu: Matsuri (a8085)
s2         - Baka to Test to Shoukanjuu Ni! (a8235)
```

**"Ranma ½"**
http://anidb.net/perl-bin/animedb.pl?show=rel&aid=193
https://www.thetvdb.com/series/ranma-1-2/seasons/all
```
#### FROM: ####
s1          - Ranma 1/2 (a4576)
s1->s7      - Ranma 1/2 Nettou Hen (a193)
s0e03->08   - Ranma 1/2 (1993) (a405)
s0e09/10    - Ranma 1/2 Special (a2995)
s0e11       - Ranma 1/2: Chou Musabetsu Kessen! Ranma Team VS Densetsu no Houou (a2850)
s0e12/13/14 - Ranma 1/2 Super (a2996)
#### TO: ####
s1     - Ranma 1/2 (a4576)
s1->s7 - Ranma 1/2 Nettou Hen (a193)
s8     - Ranma 1/2 (1993) (a405)
s9     - Ranma 1/2 Special (a2995)
s10    - Ranma 1/2: Chou Musabetsu Kessen! Ranma Team VS Densetsu no Houou (a2850)
s11    - Ranma 1/2 Super (a2996)
```

**"Maken-Ki! Battling Venus"**
http://anidb.net/perl-bin/animedb.pl?show=rel&aid=8265
https://www.thetvdb.com/series/maken-ki-battling-venus/seasons/all
```
#### FROM: ####
s1   - Maken-ki! (a8265)
s0e7 - Maken-ki!: Natsu Da! Mizugi Da! Gasshuku Da! (a8566)
s0e8 - Maken-ki! Two: Takeru Nyotaika!? Minami no Shima de Supoon (a10191)
s2   - Maken-ki! Two (a9406)
#### TO: ####
s1     - Maken-ki! (a8265)
s1e101 - Maken-ki!: Natsu Da! Mizugi Da! Gasshuku Da! (a8566)
s1e201 - Maken-ki! Two: Takeru Nyotaika!? Minami no Shima de Supoon (a10191)
s2     - Maken-ki! Two (a9406)
```

----

### 'anidb4' - Uses ScudLee mapping to map the AniDB series to TVDB entries BUT overrides the mapping for TVDB seasons entries and puts them in AniDB relational order by inserting new seasons and pushing later TVDB seasons back

Same as 'anidb3' ordering. But instead of adding in series at the end of existing seasons, it will create a new season and push all later tvdb seasons back.

**NOTE**: AniDB series that are prequels to the series that is mapped to TVDB season 1 will stay as specials. Do any even exist? This mode could potentially make season 1 the root prequel. Let me know if there is a case/example of this being true.

**NOTE**: As no HAMA setup yet for the 'tvdb6' merged mode from 'anidb4', it will be worse than 'anidb3' that just had missing episode info.

### EXAMPLES:
```
#### FROM: ####
s1   - Date a Live (a8808)
s0e1 - Date a Live: Date to Date (a9734)
s2   - Date a Live II (a9935)
s0e2 - Date a Live II: Kurumi Star Festival (a10568)
s3   - TBD (prep entry in TVDB)
#### TO: ####
s1 - Date a Live (a8808)
s2 - Date a Live: Date to Date (a9734)
s3 - Date a Live II (a9935)
s4 - Date a Live II: Kurumi Star Festival (a10568)
```
```
#### FROM: ####
s1       - Baka to Test to Shoukanjuu (a6747)
s0e09/10 - Baka to Test to Shoukanjuu: Matsuri (a8085)
s2       - Baka to Test to Shoukanjuu Ni! (a8235)
#### TO: ####
s1 - Baka to Test to Shoukanjuu (a6747)
s2 - Baka to Test to Shoukanjuu: Matsuri (a8085)
s3 - Baka to Test to Shoukanjuu Ni! (a8235)
```
```
#### FROM: #### (unchanged from 'anidb3')
s1          - Ranma 1/2 (a4576)
s1->s7      - Ranma 1/2 Nettou Hen (a193)
s0e03->08   - Ranma 1/2 (1993) (a405)
s0e09/10    - Ranma 1/2 Special (a2995)
s0e11       - Ranma 1/2: Chou Musabetsu Kessen! Ranma Team VS Densetsu no Houou (a2850)
s0e12/13/14 - Ranma 1/2 Super (a2996)
#### TO: ####
s1     - Ranma 1/2 (a4576)
s1->s7 - Ranma 1/2 Nettou Hen (a193)
s8     - Ranma 1/2 (1993) (a405)
s9     - Ranma 1/2 Special (a2995)
s10    - Ranma 1/2: Chou Musabetsu Kessen! Ranma Team VS Densetsu no Houou (a2850)
s11    - Ranma 1/2 Super (a2996)
```
```
#### FROM: ####
s1   - Maken-ki! (a8265)
s0e7 - Maken-ki!: Natsu Da! Mizugi Da! Gasshuku Da! (a8566)
s0e8 - Maken-ki! Two: Takeru Nyotaika!? Minami no Shima de Supoon (a10191)
s2   - Maken-ki! Two (a9406)
#### TO: ####
s1 - Maken-ki! (a8265)
s2 - Maken-ki!: Natsu Da! Mizugi Da! Gasshuku Da! (a8566)
s3 - Maken-ki! Two: Takeru Nyotaika!? Minami no Shima de Supoon (a10191)
s4 - Maken-ki! Two (a9406)
```

----

### Scanner can be pulled down from here if anyone wants to test it out before merge.
https://raw.githubusercontent.com/ZeroQI/Absolute-Series-Scanner/EndOfLine369-anidb3/Scanners/Series/Absolute%20Series%20Scanner.py