### PR TITLE
Fix crash for non english path

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -216,7 +216,7 @@ def set_logging(foldername='', filename='', backup_count=0, format='%(message)s'
 
   filename = os_filename_clean_string(filename) if filename else '_root_.scanner.log'
   LOG_FILE = os.path.join(CACHE_PATH, filename)
-  if os.sep=="\\":  LOG_FILE = winapi_path(LOG_FILE) # Bypass DOS path MAX_PATH limitation
+  if os.sep=="\\":  LOG_FILE = winapi_path(LOG_FILE, 'utf-8') # Bypass DOS path MAX_PATH limitation
 
   mode = 'a' if os.path.exists(LOG_FILE) and os.stat(LOG_FILE).st_mtime + 3600 > time.time() else mode # Override mode for repeat manual scans or immediate rescans
 


### PR DESCRIPTION
```
Oct 27, 2018 16:42:51.779 [1120] ERROR - Error in Python: Running scanner:
Traceback (most recent call last):
  File "C:\Users\JayXon\AppData\Local\Plex Media Server\Scanners\Series\Absolute Series Scanner.py", line 472, in Scan
    set_logging(foldername=PLEX_LIBRARY[root] if root in PLEX_LIBRARY else '', filename=log_filename+'.filelist.log', mode='w') #add grouping folders filelist
  File "C:\Users\JayXon\AppData\Local\Plex Media Server\Scanners\Series\Absolute Series Scanner.py", line 219, in set_logging
    if os.sep=="\\":  LOG_FILE = winapi_path(LOG_FILE) # Bypass DOS path MAX_PATH limitation
  File "C:\Users\JayXon\AppData\Local\Plex Media Server\Scanners\Series\Absolute Series Scanner.py", line 201, in winapi_path
    if path.startswith(u"\\\\"):  return u"\\\\?\\UNC\\" + path[2:]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 109: ordinal not in range(128)
Oct 27, 2018 16:42:51.779 [1120] ERROR - We got an error scanning in D:\Anime
```