### PR TITLE
[anidb2/3/4] mode fallback to [anidb] if tvdb match fails

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -689,7 +689,8 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
         except Exception as e:  Log.error("Error parsing ScudLee's file content, Exception: '%s'" % e)
       
       # Set folder_show from successful mapping
-      if a2_tvdbid:  folder_show = clean_string(folder_show)+" [tvdb-%s]" % a2_tvdbid
+      if a2_tvdbid: folder_show = clean_string(folder_show) + " [tvdb-%s]" % a2_tvdbid
+      else: folder_show = clean_string(folder_show) + " [anidb-%s]" % (id)
       Log.info("".ljust(157, '-'))
     
     if source in ["anidb3", "anidb4"]:
@@ -772,7 +773,8 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
               if key.startswith("s1"): del mappingList[key]
             Log.info("anidbid: '%s', tvdbid: '%s', max_season: '%s', mappingList: %s, season_map: %s" % (id, a3_tvdbid, max_season, str(mappingList), str(season_map)))
           else: Log.info("anidbid: '%s', tvdbid: '%s', max_season: '%s', season_map: %s, no override set so using unmodified mapping" % (id, a3_tvdbid, max_season, str(season_map)))
-          folder_show = clean_string(folder_show) + " [tvdb%s-%s]" % ('' if source=="anidb3" else "6", a3_tvdbid)
+          if a3_tvdbid: folder_show = clean_string(folder_show) + " [tvdb%s-%s]" % ('' if source=="anidb3" else "6", a3_tvdbid)
+          else: folder_show = clean_string(folder_show) + " [anidb-%s]" % (id)
         except Exception as e:  Log.error("Error parsing content, Exception: '%s'" % e)
       Log.info("".ljust(157, '-'))
 


### PR DESCRIPTION
As discussed [#243]; this allows the scanner to fallback from forced `[anidb2/3/4]` modes back to `[anidb]` mode when there is no tvdb match.

The idea here is to prevent `[tvdb-]` entries which would end up being merged by Plex under a single entry.

PR has been tested with a library of under `[anidb3]` mode with a few temporary entries under `[anidb2]` mode.
`[anidb4]` mode should behave exactly as `[anidb3]` mode but there have been no tests under `[tvdb/2/3/4]` modes (which this PR doesn't touch).

So far I haven't seen any side-effects but please review before merging.

---
###### resolves #243