### PR TITLE
Add ability for youtube channel seasons and episode order be specified by filename date

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -152,7 +152,7 @@ WS_MULTI_EP_SIMPLE  = com(r"^(?P<ep>\d{1,3})-(?P<ep2>\d{1,3})$")
 WS_MULTI_EP_COMPLEX = com(r"^(ep?[ -]?)?(?P<ep>\d{1,3})(-|ep?|-ep?)(?P<ep2>\d{1,3})")
 WS_SPECIALS         = com(r"^((t|o)\d{1,3}$|(sp|special|op|ncop|opening|ed|nced|ending|trailer|promo|pv|others?)(\d{1,3})?$)")
 # Switch to turn on youtube date scanning
-SW_YOUTUBE_DATE     = True
+SW_YOUTUBE_DATE     = False
 
 ### Setup core variables ################################################################################
 def setup():

--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -968,12 +968,13 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
       ### YouTube Channel numbering ###
       if source.startswith('youtube') and id.startswith('UC'):
         filename = os.path.basename(file)
-	if re.match("/^([12]\d{3}[-. ](0[1-9]|1[0-2])[-. ](0[1-9]|[12]\d|3[01])).*/",filename):
-		folder_season = int(filename[0:4])
-		Log.info('Youtube folder season regex,  season: {}, file: {}'.format(folder_season, filename))
-	else:
-		folder_season = time.gmtime(os.path.getmtime(os.path.join(root, path, filename)) )[0]
-		Log.info('Youtube folder season regex,  season: {}, file: {}'.format(folder_season, filename))
+        folder_season=0
+        if ((re.match("^([12]\d{3}[-. ](0[1-9]|1[0-2])[-. ](0[1-9]|[12]\d|3[01]))",filename) is not None) or (re.match("^([12]\d{3}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))",filename) is not None)):
+          folder_season = int(filename[0:4])
+          Log.info('Youtube folder season regex,  season: {}, file: {}'.format(folder_season, filename))
+        else:
+          folder_season = time.gmtime(os.path.getmtime(os.path.join(root, path, filename)) )[0]
+          Log.info('Youtube folder season gmtime,  season: {}, file: {}'.format(folder_season, filename))
         ep            = files_per_date.index(filename)+1 if filename in files_per_date else 0
         standard_holding.append([os.path.join(root, path, filename), root, path, folder_show if id in folder_show else folder_show+'['+id+']', int(folder_season if folder_season is not None else 1), ep, filename, folder_season, ep, 'YouTube', tvdb_mapping, unknown_series_length, offset_season, offset_episode, mappingList])
         continue

--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -900,7 +900,7 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
       else:  Log.info('json_full is empty')
     files_per_date = []
     if id.startswith('UC') or id.startswith('HC'):
-      files_per_date = sorted([os.path.basename(file) for file in files], key=getmtime) #to have latest ep first, add: ", reverse=True"
+      files_per_date = sorted([os.path.basename(file) for file in files], key=natural_sort_key) #to have latest ep first, add: ", reverse=True"
       Log.info('files_per_date: {}'.format(files_per_date))
       
     ### Build misc variable to check numbers in titles ###
@@ -968,7 +968,12 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
       ### YouTube Channel numbering ###
       if source.startswith('youtube') and id.startswith('UC'):
         filename = os.path.basename(file)
-        folder_season = time.gmtime(os.path.getmtime(os.path.join(root, path, filename)) )[0]
+	if re.match("/^([12]\d{3}[-. ](0[1-9]|1[0-2])[-. ](0[1-9]|[12]\d|3[01])).*/",filename):
+		folder_season = int(filename[0:4])
+		Log.info('Youtube folder season regex,  season: {}, file: {}'.format(folder_season, filename))
+	else:
+		folder_season = time.gmtime(os.path.getmtime(os.path.join(root, path, filename)) )[0]
+		Log.info('Youtube folder season regex,  season: {}, file: {}'.format(folder_season, filename))
         ep            = files_per_date.index(filename)+1 if filename in files_per_date else 0
         standard_holding.append([os.path.join(root, path, filename), root, path, folder_show if id in folder_show else folder_show+'['+id+']', int(folder_season if folder_season is not None else 1), ep, filename, folder_season, ep, 'YouTube', tvdb_mapping, unknown_series_length, offset_season, offset_episode, mappingList])
         continue


### PR DESCRIPTION
Currently for youtube channels (UC) the seasons and episode order are set\ordered by file modification date.    On my system I have numerous files where the modification date is wrong for one reason or another and episodes are in the wrong seasons or in the wrong order.

When downloading the channel, I begin all filenames with yyyymmdd - * so the information to order the files is already in the filename.  I modified the scanner to order files by filename and then extract the season from the date in the filename.

Other than the sorting change, I believe all other edits should be transparent to users that don't follow this naming convention - but to ensure it wouldn't affect users unintentionally I tied the new behavior to an option boolean and defaulted it to off.  As I know some start their filenames in a similar way with date first I figured others could benefit from this change.
