### PR TITLE
TVDB ID for Ikebukuro West Gate Park

### DIFF
--- a/anime-list-corrections.xml
+++ b/anime-list-corrections.xml
@@ -19,4 +19,8 @@
   <anime anidbid="14203" tvdbid="82484" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Dai 501 Tougou Sentou Koukuu Dan Strike Witches: Road to Berlin</name>
   </anime>
+  <!-- https://github.com/ScudLee/anime-lists/pull/359 -->
+  <anime anidbid="15073" tvdbid="381769" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+    <name>Ikebukuro West Gate Park</name>
+  </anime>
 </anime-list>


### PR DESCRIPTION
The previous TVDB ID was for an old show with the same name, this one matches the AniDB ID