### PR TITLE
Encode filename before checking existence, Fix #353

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -390,9 +390,13 @@ def add_episode_into_plex(media, file, root, path, show, season=1, ep=1, title="
   if isinstance(title, unicode):  utitle= title; title = title.encode('utf-8')  #Plex expect Title in UTF-8
   else:                           utitle= title.decode('utf-8')
   
-  if not os.path.exists(file):  file = os.path.join(root, path, file)
   if isinstance(file,  unicode):  ufile = os.path.basename(file);   file = file.encode(sys.getfilesystemencoding() or 'utf-8')
   else:                           ufile = os.path.basename(file.decode('utf-8'))
+  
+  try:
+    if not os.path.exists(file):  file = os.path.join(root, path, file)
+  except Exception as e:
+    Log.error("Failed to check path %s, Exception: %s" % (ufile, e))
   
   # Season/Episode Offset
   if isinstance(ep, int) or isinstance(ep, str) and ep.isdigit():  #date-based


### PR DESCRIPTION
- Move encoding / decoding before exists check.
- Prevent that the directory isn't further scanned if exists check fails.

This fixed #353 for me, the `except`  message isn't logged, so most likely the necessary fix was the encoding before checking.

Log result:
Test2.scanner.log
```
=============================================================================================================================================================
Call: "Plex", path: "Test2", folder_show: "Test2", dirs (0), files (3)
=============================================================================================================================================================
"Test2" s01e         4                         "Word Search" "Entführt" "Fullmetal Panic! - 04 - Entführt.mkv"
"Test2" s01e         5                         "Word Search" "Entführt - Kopie" "Fullmetal Panic! - 05 - Entführt - Kopie.mkv"
"Test2" s01e         2                         "Word Search" "Das unartige Mädchen" "Fumetsu no Anata e - 02 - Das unartige Mädchen.mkv"
=============================================================================================================================================================
```

Plex Media Scanner.log
```
Jun 05, 2021 12:58:45.445 [14969] DEBUG - Performing a scan with 'Absolute Series Scanner' (language: de virtual: 0).
Jun 05, 2021 12:58:45.446 [14969] DEBUG -   * Scanning /storage/FLEXSTATION/Plex/Share/Anime
Jun 05, 2021 12:58:45.459 [14969] DEBUG - Scanner: Processing directory /storage/FLEXSTATION/Plex/Share/Anime (parent: no)
Jun 05, 2021 12:58:45.507 [14969] DEBUG - Skipping over directory '', as nothing has changed; removing 0 media items from map.
Jun 05, 2021 12:58:52.102 [14969] DEBUG - Scanner: Processing directory /storage/FLEXSTATION/Plex/Share/Anime/Test2 (parent: yes)
Jun 05, 2021 12:58:52.165 [14969] DEBUG - Directory had 3 files, database had 2 files, can't skip.
Jun 05, 2021 12:58:52.302 [14969] DEBUG - Looking for path match for [/storage/FLEXSTATION/Plex/Share/Anime/Test2/Fullmetal Panic! - 04 - Entführt.mkv]
Jun 05, 2021 12:58:52.305 [14969] DEBUG - Path matched, we're reusing media item 41142
Jun 05, 2021 12:58:52.305 [14969] DEBUG - Looking for path match for [/storage/FLEXSTATION/Plex/Share/Anime/Test2/Fullmetal Panic! - 05 - Entführt - Kopie.mkv]
Jun 05, 2021 12:58:52.308 [14969] DEBUG - Path matched, we're reusing media item 41143
Jun 05, 2021 12:58:52.308 [14969] DEBUG - Looking for path match for [/storage/FLEXSTATION/Plex/Share/Anime/Test2/Fumetsu no Anata e - 02 - Das unartige Mädchen.mkv]
Jun 05, 2021 12:58:52.385 [14969] DEBUG - Checking by hash to see if we can find a match with 744a52022de1e6c826d79b1a3c6aad3662bee255 (display offset: 0, not part -1)
Jun 05, 2021 12:58:52.385 [14969] DEBUG - We found a hash match for [/storage/FLEXSTATION/Plex/Share/Anime/Test2/Fumetsu no Anata e - 02 - Das unartige Mädchen.mkv] which was [/storage/FLEXSTATION/Plex/Share/Anime/Fumetsu no Anata e/Fumetsu no Anata e - 02 - Das unartige Mädchen.mkv].
Jun 05, 2021 12:58:52.414 [14969] WARN - Duplicate media part detected [/storage/FLEXSTATION/Plex/Share/Anime/Fumetsu no Anata e/Fumetsu no Anata e - 02 - Das unartige Mädchen.mkv], but we'll scan it anyway.
Jun 05, 2021 12:58:52.414 [14969] DEBUG - Hint show didn't match ('Test2' != 'Fumetsu no Anata e') for DB media item 40839
Jun 05, 2021 12:58:52.415 [14969] DEBUG - Checking descendants of Test2
Jun 05, 2021 12:58:52.418 [14969] DEBUG -  -> FOUND metadata item (show)
Jun 05, 2021 12:58:52.418 [14969] DEBUG -  -> We found a local media item with rooted metadata in Test2
```