### PR TITLE
Prefer content of X-Plex-Token.id file over env variable

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -168,7 +168,7 @@ def setup():
   Log.info(u"".ljust(157, '='))
   Log.info(u"Plex scan start: {}".format(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")))
   try:
-    library_xml = etree.fromstring(read_url(Request(PLEX_LIBRARY_URL, headers={"X-Plex-Token": os.environ['PLEXTOKEN']})))
+    library_xml = etree.fromstring(read_url(Request(PLEX_LIBRARY_URL, headers={"X-Plex-Token": read_file(os.path.join(PLEX_ROOT, "X-Plex-Token.id")).strip() if os.path.isfile(os.path.join(PLEX_ROOT, "X-Plex-Token.id")) else Dict(os.environ, 'PLEXTOKEN')})))
     for directory in library_xml.iterchildren('Directory'):
       for location in directory.iterchildren('Location'):
         PLEX_LIBRARY[location.get('path')] = {'title': directory.get('title'), 'scanner': directory.get("scanner"), 'agent': directory.get('agent')}


### PR DESCRIPTION
On my OS (freebsd), I noticed that there is no env variable named PLEXTOKEN. There is however an X-PLEX-TOKEN. This change checks for the existence of an X-Plex-Token.id file and uses its content (these are instructions provided on the readme) and uses that instance.

A simpler change would be to check for an OS environment variable named X-PLEX-TOKEN if that is common across environments, but I dont know whats more common and this might be the least disruptive change.