### PR TITLE
Fixes a bug in specials ordering for forced 'anidb'

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -1179,7 +1179,7 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
 
             ### OP/ED with letter version Example: op2a
             if not ep.isdigit() and len(ep)>1 and ep[:-1].isdigit():  ep, offset = int(ep[:-1]), ord(ep[-1:])-ord('a')
-            else:                                                     offset = 0
+            else:                                                     ep, offset = int(ep), 0
             if anidb_xml is None:
               if ANIDB_RX.index(rx) in AniDB_op:  AniDB_op[ANIDB_RX.index(rx)]   [ep] = offset # {101: 0 for op1a / 152: for ed2b} and the distance between a and the version we have hereep, offset                         = str( int( ep[:-1] ) ), offset + sum( AniDB_op.values() )                             # "if xxx isdigit() else 1" implied since OP1a for example... # get the offset (100, 150, 200, 300, 400) + the sum of all the mini offset caused by letter version (1b, 2b, 3c = 4 mini offset)
               else:                               AniDB_op[ANIDB_RX.index(rx)] = {ep:   offset}


### PR DESCRIPTION
Fixes #397 

If specials contained an alphabetical character (i.e. 2a / 2b), the script would perform a string / integer comparison which could throw off the `cumulative_offset` (for example, `2 < '1' == true`).

This fixes this so that the variable `ep` is always an integer value when being compared in the initialisation of `cumulative_offset`.