### PR TITLE
Trim dupe index from episode

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -1018,7 +1018,7 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
         for episode in mapping[season] or []:
           filename = Dict(mapping, season, episode)
           if not isinstance(filename, int):
-            add_episode_into_plex(media, filename, root, path, folder_show if not id or id in folder_show else folder_show+'['+id+']', int(season), episode, os.path.basename(filename), season, "", "Youtube Date", tvdb_mapping, unknown_series_length, offset_season, offset_episode, mappingList)
+            add_episode_into_plex(media, filename, root, path, folder_show if not id or id in folder_show else folder_show+'['+id+']', int(season), episode[0:10], os.path.basename(filename), season, "", "Youtube Date", tvdb_mapping, unknown_series_length, offset_season, offset_episode, mappingList)
       return
 
     ### Build misc variable to check numbers in titles ###


### PR DESCRIPTION
Noticed an issue with [YouTube-Agent](https://github.com/ZeroQI/YouTube-Agent.bundle) where videos with the same upload date (e.g. [U_SM507Q-aU)](https://www.youtube.com/watch?v=U_SM507Q-aU) and [uKmQTE8iYqI](https://www.youtube.com/watch?v=uKmQTE8iYqI)) wouldn't have any metadata in Plex.

There's an error in the YouTube-Agent logs:

```
2022-03-12 13:08:34,957 (7f0fdb920b38) :  CRITICAL (agentkit:1095) - Exception in the update function of agent named 'YouTubeSeries', called with guid 'com.plexapp.agents.youtube://youtube|UCU7iRrk3xfpUk0R6VdyC1Ow|NBA on TNT [UCU7iRrk3xfpUk0R6VdyC1Ow]/2022/1900-01-01?lang=xn' (most recent call last):
  File "/usr/lib/plexmediaserver/Resources/Plug-ins-c8bd13540/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/api/agentkit.py", line 1093, in _update
    agent.update(obj, media, lang, **kwargs)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/YouTube-Agent.bundle/Contents/Code/__init__.py", line 518, in update
    def update (self, metadata, media, lang, force ):  Update (metadata, media, lang, force,  False)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/YouTube-Agent.bundle/Contents/Code/__init__.py", line 490, in Update
    if len(e)>3:  episode.originally_available_at = Datetime.ParseDate(json_video_details['snippet']['publishedAt']).date();                       Log.Info('[ ] date:     "{}"'.format(json_video_details['snippet']['publishedAt']))
TypeError: object of type 'NoneType' has no len()
```

The error is happening on this line:

https://github.com/ZeroQI/YouTube-Agent.bundle/blob/8fa23c42f413230fe67751cfd75efa622a482b05/Contents/Code/__init__.py#L490

And the YouTube-Agent logs show that the value for `e` (representing the episode "number") here is `None`:

```
2022-03-12 13:08:34,945 (7f0fdb920b38) :  INFO (__init__:417) - metadata.seasons[2022].episodes[None] "Shaq Gets Chuck Mad With Yet ANOTHER 'Rings' Joke _ NBA on TNT [U_SM507Q-aU] (2022-02-10).mkv"
```

(Note the `metadata.seasons[2022].episodes[None]` debugging statement)

Based on the Absolute Series Scanner logs, it looks like the scanner is adding the "episode" as the episode-with-dupe-index value:

```
"NBA on TNT [youtube-UCU7iRrk3xfpUk0R6VdyC1Ow]" s2022e2022-02-1001                         "Youtube Date" "LeBron James & Kevin Durant Make Their Picks In The 2022 NBA All-Star Draft _ NBA on TNT [uKmQTE8iYqI] (2022-02-10).mkv" "LeBron James & Kevin Durant Make Their Picks In The 2022 NBA All-Star Draft _ NBA on TNT [uKmQTE8iYqI] (2022-02-10).mkv"
"NBA on TNT [youtube-UCU7iRrk3xfpUk0R6VdyC1Ow]" s2022e2022-02-1002                         "Youtube Date" "Shaq Gets Chuck Mad With Yet ANOTHER 'Rings' Joke _ NBA on TNT [U_SM507Q-aU] (2022-02-10).mkv" "Shaq Gets Chuck Mad With Yet ANOTHER 'Rings' Joke _ NBA on TNT [U_SM507Q-aU] (2022-02-10).mkv"
```

So this PR truncates any extra "dupe" indicators in the episode date so the episode metadata can be set correctly