### PR TITLE
Youtube2 switch for same date episode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ You can specify the guid to use the following way:
 <UL><LI>Star Wars: The Clone Wars [tvdb5-83268] </LI></UL>
 </TD> </TR>
         <TR> <TD> youtube     </TD> <TD> YouTube                    </TD> <TD> None             </TD> <TD> None          </TD> <TD> Put Playlist id (PL... 2+16/32 chars long) on series folder or season folder (auto-reversing) or channel id on series folder (year used as season, added as date-based unless there are duplicates for the date in which case it choose ep number MMDDxx with XX being incremental)</TD> </TR>
+        <TR> <TD> youtube2     </TD> <TD> YouTube                    </TD> <TD> None             </TD> <TD> None          </TD> <TD> Recommended for channels that release multiple episodes per day. Put channel id on series folder (year used as season, episodes added as MMDDhhmm. If date not present in filename, will use the files date for Month, Day, Hour and Minute, but if the date is present in the filename than Month and Day are pulled from it instead)</TD> </TR>
 </TBODY>
 </TABLE>
 

--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -1002,11 +1002,18 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
         for rx in DATE_RX:
           match = rx.search(file)  # file starts with "yyyy-mm-dd" "yyyy.mm.dd" "yyyy mm dd" or "yyyymmdd"
           if match:
-            season, episode = match.group('year'), '{}-{:>02}-{:>02}'.format(match.group('year'), match.group('month'), match.group('day'))
+            if source=='youtube2': 
+              filedate        = time.gmtime(os.path.getmtime(filename))
+              season, episode = match.group('year'), '{:>02}{:>02}{:>02}{:>02}'.format(match.group('month'), match.group('day'), filedate[3], filedate[4])
+            else:
+              season, episode = match.group('year'), '{}-{:>02}-{:>02}'.format(match.group('year'), match.group('month'), match.group('day'))
             break
         else:
           filedate        = time.gmtime(os.path.getmtime(filename))
-          season, episode = str(filedate[0]), '{}-{:>02}-{:>02}'.format(filedate[0], filedate[1], filedate[2])
+          if  source=='youtube2':
+            season, episode = str(filedate[0]), '{:>02}{:>02}{:>02}{:>02}'.format(filedate[1], filedate[2], filedate[3], filedate[4])
+          else:
+            season, episode = str(filedate[0]), '{}-{:>02}-{:>02}'.format(filedate[0], filedate[1], filedate[2])
         if isinstance(season,  unicode):  season  =  season.encode('utf-8')
 
         if not Dict(mapping, season, episode):  SaveDict(filename, mapping, season, episode)


### PR DESCRIPTION
Took a stab at altering to provide further support for channels that may release multiple episodes on a given day, so it plays nicer with the Youtube agent. The constructed episode numbers allow the episodes to remain unique and the Meta Agent to correctly pull and apply metadata to the episodes. The 8 digit episode numbers are certainly more unsightly than the episodes being displayed by date, but supplies "better" functionality in the given circumstance.

Still not 100% duplicate proof as you could end up with two episodes on the same day that managed to also be modified within the same minute. However the likelihood of this seems lower than the probability that the current implementation fails (due to Plex limitations).

Felt using the Hour/Minute as an "index" provided more robustness when it comes to seasons that may have episodes added/deleted down the road over an arbitrary "index" that's applied and could change by simply added/deleted something? Seems this would better preserve the metadata and watch history?