### PR TITLE
fix not checking the rest of the string when skipping a season in word search

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -1163,7 +1163,7 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
         if not ep:                                                                                                 continue                                           #
         for prefix in ["ep", "e", "act", "s"]:                                                                                                                        #
           if ep.startswith(prefix) and len(ep)>len(prefix) and WS_DIGIT.search(ep[len(prefix):]):
-            if prefix == "s" and words.index(word) + 1 < len(words) and '-' in words[words.index(word) + 1:]:      continue                                           # don't take special if it is followed by the separator
+            if prefix == "s" and words.index(word) + 1 < len(words) and '-' in words[words.index(word) + 1:]:      skip_word = True; continue                         # don't take special if it is followed by the separator
             #Log.info(u'misc_count[word]: {}, filename.count(word)>=2: {}'.format(misc_count[word] if word in misc_count else 0, filename.count(word)))
             ep, season = ep[len(prefix):], 0 if prefix=="s" and (word not in misc_count or filename.count(word)==1 and misc_count[word]==1 or filename.count(word)>=2 and misc_count[word]==2) else season  # E/EP/act before ep number ex: Trust and Betrayal OVA-act1 # to solve s00e002 "Code Geass Hangyaku no Lelouch S5 Picture Drama 02 'Stage 3.25'.mkv" "'Stage 3 25'"
             break
@@ -1181,6 +1181,8 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
           #if   ep.isdigit() and len(ep)==4 and (int(ep)< 1900 or folder_season and int(ep[0:2])==folder_season):   season, ep = int(ep[0:2]), ep[2:4]                 # 1206 could be season 12 episode 06  #Get assigned from left ot right
           #elif ep.isdigit() and len(ep)==4:  filename = clean_string( " ".join(words).replace(ep, "(%s)" % ep));   continue                                           # take everything after supposed episode number
           if   ep.isdigit() and len(ep)==4 and int(ep)>= 1930: filename = clean_string( " ".join(words).replace(ep, "(%s)" % ep));   continue                                           # take everything after supposed episode number
+        if skip_word:
+          continue
         if "." in ep and ep.split(".", 1)[0].isdigit() and ep.split(".")[1].isdigit():                             season, ep, title = 0, ep.split(".", 1)[0], "Special " + ep; break # ep 12.5 = "12" title "Special 12.5"
         title = clean_string( " ".join(words[words.index(word):])[" ".join(words[words.index(word):]).lower().index(ep)+len(ep):] )                                   # take everything after supposed episode number
         break


### PR DESCRIPTION
#459 fixed matching `S2 - 02` as special 2 instead of episode 2, but we didn't keep advancing in the string when this happens.

if we don't have enough word matches due to small amount of files, then some specials in later seasons like `S2 - S5`
this makes it continue checking the rest of the words for a valid match