### PR TITLE
Make sure items to remove are delimited

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -1122,7 +1122,9 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
             if clean_string(filename, no_whack=True).lower().startswith(prefix.lower()):  filename = clean_string(re.sub(prefix, " ", filename, 1, re.IGNORECASE), True); break
           else:
             filename = clean_string(filename)
-            for item in misc_words:  filename = re.sub(re.escape(item), " ", filename, 1, re.IGNORECASE) ## need to escape names, otherwise words with certain characters (like c++) will make it think its an invalid regex string
+            for item in misc_words:
+              filename = re.sub(r'(^|\s|\.|\-|\_){}(\s|$|\.|\-|\_)'.format(re.escape(item)), " ", filename, re.IGNORECASE)
+            filename = re.sub(r'\s+', ' ', filename).strip()  # Remove any extra spaces
       else: filename = clean_string(filename)
       ep = filename
       if "Complete Movie" in ep:  ep = "01"  ### Movies ### If using WebAOM (anidb rename), as clean_string remove leading " - "


### PR DESCRIPTION
Very short strings could be removed from somewhere they shouldn't. This has the potential to break things. For example, if a zero ended up in misc_words, it could break the part of the string representing the season and episode. "S01E01" would become "S 1E 1" This won't match any regex looking for season/episode.