### PR TITLE
Fix episode numbering for YouTube UU channel playlists

### DIFF
--- a/Scanners/Series/Absolute Series Scanner.py
+++ b/Scanners/Series/Absolute Series Scanner.py
@@ -1022,7 +1022,10 @@ def Scan(path, files, media, dirs, language=None, root=None, **kwargs): #get cal
           except Exception as e:  json_page = {};  Log.info(u'exception: {}, url: {}'.format(e, url))
           else:                   json_full.extend( Dict(json_page, 'items', default=[]) )
           totalResults = Dict(json_page, "pageInfo", "totalResults")  #iteration   +=1
-          reverse      = False if source=='youtube3' else Dict(json_full, 0, "snippet", "publishedAt") > Dict(json_full, -1, "snippet", "publishedAt") #Dict(video, 'contentDetails', 'videoPublishedAt')
+        json_full    = [v for v in json_full if v and Dict(v, 'snippet', 'publishedAt')]
+        first_date   = json_full[0]['snippet']['publishedAt']  if json_full else ''
+        last_date    = json_full[-1]['snippet']['publishedAt'] if json_full else ''
+        reverse      = False if source=='youtube3' else first_date > last_date
         if json_full:
           Log.info(u'---- totalResults: {}, reverse: {}, os.listdir(os.path.join(root, path): {}'.format(totalResults, reverse, os.listdir(os.path.join(root, path))))
           for filename in os.listdir(os.path.join(root, path)):


### PR DESCRIPTION
This PR fixes a bug that I discovered when I recently upgrading to the latest version of ASS (after being on an old version for a very long time).

The problem: When using YouTube UU channel playlists, matched videos were being assigned the wrong episode number (usually very low numbers despite being recent videos) instead of their correct position in the channel.

I found two bugs on the same line inside the pagination while loop:

```
    reverse = False if source=='youtube3' else Dict(json_full, 0, "snippet", "publishedAt") > Dict(json_full, -1, "snippet", "publishedAt")
```

1. `Dict()` in ASS only handles dicts, not lists. `Dict(json_full, 0, ...)` always returns `""` regardless of the list contents, so the comparison was always `"" > ""` = `False`. This means `reverse` was permanently `False` for all playlists, causing the newest video (rank 0 in a newest-first API response) to always get `epNumber = rank + 1 = 1`.

2. Private or deleted videos in the playlist return null entries with no `publishedAt`. These would corrupt the comparison even if list indexing worked correctly.

### Fix

Move the `reverse` calculation outside the while loop (so it uses the fully populated list), filter out null entries, then use direct list indexing:

```
    json_full  = [v for v in json_full if v and Dict(v, 'snippet', 'publishedAt')]
    first_date = json_full[0]['snippet']['publishedAt']  if json_full else ''
    last_date  = json_full[-1]['snippet']['publishedAt'] if json_full else ''
    reverse    = False if source=='youtube3' else first_date > last_date
```

Tested and seems to work well for me!